### PR TITLE
initialization: better error handling for a YAML file that is missing the required namespace section

### DIFF
--- a/lib/settingslogic.rb
+++ b/lib/settingslogic.rb
@@ -103,7 +103,9 @@ class Settingslogic < Hash
       self.replace hash_or_file
     else
       hash = YAML.load(ERB.new(File.read(hash_or_file)).result).to_hash
-      hash = hash[self.class.namespace] if self.class.namespace
+      if self.class.namespace
+        hash = hash[self.class.namespace] or raise MissingSetting, "Missing setting '#{self.class.namespace}' in #{hash_or_file}"
+      end
       self.replace hash
     end
     @section = section || self.class.source  # so end of error says "in application.yml"


### PR DESCRIPTION
We've been bitten by this a couple of times. We've got a different YAML file per environment and the config blocks in the files are namespaced accordingly with "development", "production", etc. If we happen to accidentally pass the development YAML file to the production app, it will open up the YAML file and attempt to find a "production" section that isn't there. Then instead of letting us know what the actual problem is (can't find a "production" section in the YAML file), the initialize() method ignores the fact that the section was missing and proceeds to attempt "self.replace hash" with "hash" being nil.

This tiny update to initialize() will trap for the condition of the missing namespace section and raise an informative exception instead of the somewhat less helpful "can't convert nil into Hash" one we're seeing now.
