### PR TITLE
fix for issue #11 - ZenTest conflict with .name property of Settingslogic class

### DIFF
--- a/lib/settingslogic.rb
+++ b/lib/settingslogic.rb
@@ -7,7 +7,7 @@ class Settingslogic < Hash
 
   class << self
     def name # :nodoc:
-      instance.key?("name") ? instance.name : super
+      self.superclass != Hash && instance.key?("name") ? instance.name : super
     end
 
     # Enables Settings.get('nested.key.name') for dynamic access

--- a/spec/settingslogic_spec.rb
+++ b/spec/settingslogic_spec.rb
@@ -133,9 +133,26 @@ describe "Settingslogic" do
     Settings.get('setting1.deep.child.value').should == 2
   end
 
+  # If .name is not a property, delegate to superclass
+  it "should respond with Module.name" do
+    Settings2.name.should == "Settings2"
+  end
+
+  # If .name is called on Settingslogic itself, handle appropriately
+  # by delegating to Hash
+  it "should have the parent class always respond with Module.name" do
+    Settingslogic.name.should == 'Settingslogic'
+  end
+
+  # If .name is a property, respond with that instead of delegating to superclass
+  it "should allow a name setting to be overriden" do
+    Settings.name.should == 'test'
+  end
+
   # Put this test last or else call to .instance will load @instance,
   # masking bugs.
   it "should be a hash" do
     Settings.send(:instance).should be_is_a(Hash)
   end
+  
 end


### PR DESCRIPTION
I ran into the same problem with ZenTest autotester throwing stacks to stdout when it tries to call `Settingslogic.name` during its traversal of ObjectSpace. It annoyingly pollutes my console window...

Allowing `name` as a setting value is a very useful feature, so I enhanced the conditional to prevent calling `instance` when name is called directly on `Settingslogic`.

Tests are updated to include a test for the existing .name behavior and the desired behavior when calling the superclass.
