### PR TITLE
Rails.root is not app/

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -48,7 +48,7 @@ to a key in the YAML file.
 
 Using a namespace allows us to change our configuration depending on our environment:
 
-  # app/config/application.yml
+  # config/application.yml
   defaults: &defaults
     cool:
       saweet: nested settings


### PR DESCRIPTION
`Rails.root` is used in the example and the path to application.yml is given as `app/config/application.yml`

app is not `Rails.root`. This may cause confusion for less experienced developers. 
