### PR TITLE
Bundler and Suppressing Errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ pkg/*
 coverage/*
 doc/*
 benchmarks/*
-
+.bundle
+vendor/bundle

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source "http://rubygems.org"
+
+gem 'rake', '0.8.7'
+gem 'jeweler'
+gem 'rspec', :require => 'spec'
+gem 'ruby-debug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,36 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    columnize (0.3.6)
+    diff-lcs (1.1.3)
+    git (1.2.5)
+    jeweler (1.6.4)
+      bundler (~> 1.0)
+      git (>= 1.2.5)
+      rake
+    linecache (0.46)
+      rbx-require-relative (> 0.0.4)
+    rake (0.8.7)
+    rbx-require-relative (0.0.5)
+    rspec (2.8.0)
+      rspec-core (~> 2.8.0)
+      rspec-expectations (~> 2.8.0)
+      rspec-mocks (~> 2.8.0)
+    rspec-core (2.8.0)
+    rspec-expectations (2.8.0)
+      diff-lcs (~> 1.1.2)
+    rspec-mocks (2.8.0)
+    ruby-debug (0.10.4)
+      columnize (>= 0.1)
+      ruby-debug-base (~> 0.10.4.0)
+    ruby-debug-base (0.10.4)
+      linecache (>= 0.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jeweler
+  rake (= 0.8.7)
+  rspec
+  ruby-debug

--- a/README.rdoc
+++ b/README.rdoc
@@ -114,7 +114,7 @@ Modifying our model example:
 This would allow you to specify a custom value for per_page just for posts, or
 to fall back to your default value if not specified.
 
-=== 4. Suppressing Exceptions Conditionally
+=== 5. Suppressing Exceptions Conditionally
 
 Raising exceptions for missing settings helps highlight configuration problems.  However, in a
 Rails app it may make sense to suppress this in production and return nil for missing settings.

--- a/README.rdoc
+++ b/README.rdoc
@@ -114,6 +114,22 @@ Modifying our model example:
 This would allow you to specify a custom value for per_page just for posts, or
 to fall back to your default value if not specified.
 
+=== 4. Suppressing Exceptions Conditionally
+
+Raising exceptions for missing settings helps highlight configuration problems.  However, in a
+Rails app it may make sense to suppress this in production and return nil for missing settings.
+While it's useful to stop and highlight an error in development or test environments, this is
+often not the right answer for production.
+
+  class Settings < Settingslogic
+    source "#{Rails.root}/config/application.yml"
+    namespace Rails.env
+    suppress_errors Rails.env.production?
+  end
+
+  >> Settings.non_existent_key
+  => nil
+
 == Note on Sinatra / Capistrano / Vlad
 
 Each of these frameworks uses a +set+ convention for settings, which actually defines methods

--- a/spec/settings4.rb
+++ b/spec/settings4.rb
@@ -1,0 +1,4 @@
+class Settings4 < Settingslogic
+  source "#{File.dirname(__FILE__)}/settings.yml"
+  suppress_errors true
+end

--- a/spec/settingslogic_spec.rb
+++ b/spec/settingslogic_spec.rb
@@ -107,6 +107,10 @@ describe "Settingslogic" do
     e.should_not be_nil
   end
 
+  it "should allow suppressing errors" do
+    Settings4.non_existent_key.should be_nil
+  end
+
   # This one edge case currently does not pass, because it requires very
   # esoteric code in order to make it pass.  It was judged not worth fixing,
   # as it introduces significant complexity for minor gain.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'settingslogic'
 require 'settings'
 require 'settings2'
 require 'settings3'
+require 'settings4'
 
 # Needed to test Settings3
 Object.send :define_method, 'collides' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,3 @@
-require 'spec'
-require 'rubygems'
-require 'ruby-debug' if RUBY_VERSION < '1.9'  # ruby-debug does not work on 1.9.1 yet
-
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'settingslogic'
@@ -14,5 +10,5 @@ Object.send :define_method, 'collides' do
   'collision'
 end
 
-Spec::Runner.configure do |config|
+RSpec.configure do |config|
 end


### PR DESCRIPTION
Hi Ben,

I really appreciate all the open source tools you've put out there.  We've gotten some good mileage from settingslogic at PatientsLikeMe.

We ran into a bug where settings might not be defined properly in different Rails environments when using the Rails environment as a key.  This made me wish for an ability to change the settingslogic error handling depending on what Rails environment we're in - raise exceptions in dev/test but return something sensible in production.

To solve this for us, I added a new configuration option to suppress errors, with tests and documentation.

I also added bundler support and a gemfile, to make it easier for me to get the tests running and the dependencies installed to run them.

I'd love to see this pulled into the main gem, but if not - I understand.

Thanks again for publishing the gem!
-Winfield
