### PR TITLE
Fix Ruby 1.8.7 Compatibility and Gem Dependencies

### DIFF
--- a/settingslogic.gemspec
+++ b/settingslogic.gemspec
@@ -47,18 +47,30 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<rake>, [">= 0"])
       s.add_runtime_dependency(%q<jeweler>, [">= 0"])
       s.add_runtime_dependency(%q<rspec>, [">= 0"])
-      s.add_runtime_dependency(%q<ruby-debug19>, [">= 0"])
+      if RUBY_VERSION < "1.9"
+        s.add_runtime_dependency(%q<ruby-debug>, [">= 0"])
+      else
+        s.add_runtime_dependency(%q<ruby-debug19>, [">= 0"])
+      end
     else
       s.add_dependency(%q<rake>, [">= 0"])
       s.add_dependency(%q<jeweler>, [">= 0"])
       s.add_dependency(%q<rspec>, [">= 0"])
-      s.add_dependency(%q<ruby-debug19>, [">= 0"])
+      if RUBY_VERSION < "1.9"
+        s.add_dependency(%q<ruby-debug>, [">= 0"])
+      else
+        s.add_dependency(%q<ruby-debug19>, [">= 0"])
+      end
     end
   else
     s.add_dependency(%q<rake>, [">= 0"])
     s.add_dependency(%q<jeweler>, [">= 0"])
     s.add_dependency(%q<rspec>, [">= 0"])
-    s.add_dependency(%q<ruby-debug19>, [">= 0"])
+    if RUBY_VERSION < "1.9"
+      s.add_dependency(%q<ruby-debug>, [">= 0"])
+    else
+      s.add_dependency(%q<ruby-debug19>, [">= 0"])
+    end
   end
 end
 

--- a/settingslogic.gemspec
+++ b/settingslogic.gemspec
@@ -44,13 +44,13 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rake>, [">= 0"])
-      s.add_runtime_dependency(%q<jeweler>, [">= 0"])
-      s.add_runtime_dependency(%q<rspec>, [">= 0"])
+      s.add_development_dependency(%q<rake>, [">= 0"])
+      s.add_development_dependency(%q<jeweler>, [">= 0"])
+      s.add_development_dependency(%q<rspec>, [">= 0"])
       if RUBY_VERSION < "1.9"
-        s.add_runtime_dependency(%q<ruby-debug>, [">= 0"])
+        s.add_development_dependency(%q<ruby-debug>, [">= 0"])
       else
-        s.add_runtime_dependency(%q<ruby-debug19>, [">= 0"])
+        s.add_development_dependency(%q<ruby-debug19>, [">= 0"])
       end
     else
       s.add_dependency(%q<rake>, [">= 0"])


### PR DESCRIPTION
Hi Ben,

It looks like settingslogic 2.0.7 is broken for Ruby 1.8.7 based on Issue #28 and my own experience.  This seems to be caused by a new gem dependency on ruby-debug19.

I fixed the gemspec to require the right version of ruby-debug based on 1.8.7 vs. 1.9 support.

Additionally, I don't think these should be runtime gem dependencies, but development depencies - so I switched them over.

This fixes 1.8.7 compatibility for me.
-Winfield
