### PR TITLE
Fix Gemfile/Gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,12 @@
 source "http://rubygems.org"
 
-gem 'rake'
-gem 'jeweler'
-gem 'rspec', :require => 'spec'
-gem 'ruby-debug19'
+group :development do
+  gem 'rake'
+  gem 'jeweler'
+  gem 'rspec', :require => 'spec'
+  if RUBY_VERSION < "1.9"
+    gem 'ruby-debug'
+  else
+    gem 'ruby-debug19'
+  end
+end

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ group :development do
   gem 'rake'
   gem 'jeweler'
   gem 'rspec', :require => 'spec'
+  gem 'rcov'
   if RUBY_VERSION < "1.9"
     gem 'ruby-debug'
   else

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    archive-tar-minitar (0.5.2)
     columnize (0.3.6)
     diff-lcs (1.1.3)
     git (1.2.5)
@@ -9,9 +8,10 @@ GEM
       bundler (~> 1.0)
       git (>= 1.2.5)
       rake
-    linecache19 (0.5.12)
-      ruby_core_source (>= 0.1.4)
+    linecache (0.46)
+      rbx-require-relative (> 0.0.4)
     rake (0.9.2.2)
+    rbx-require-relative (0.0.5)
     rspec (2.8.0)
       rspec-core (~> 2.8.0)
       rspec-expectations (~> 2.8.0)
@@ -20,16 +20,11 @@ GEM
     rspec-expectations (2.8.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.8.0)
-    ruby-debug-base19 (0.11.25)
-      columnize (>= 0.3.1)
-      linecache19 (>= 0.5.11)
-      ruby_core_source (>= 0.1.4)
-    ruby-debug19 (0.11.6)
-      columnize (>= 0.3.1)
-      linecache19 (>= 0.5.11)
-      ruby-debug-base19 (>= 0.11.19)
-    ruby_core_source (0.1.5)
-      archive-tar-minitar (>= 0.5.2)
+    ruby-debug (0.10.4)
+      columnize (>= 0.1)
+      ruby-debug-base (~> 0.10.4.0)
+    ruby-debug-base (0.10.4)
+      linecache (>= 0.3)
 
 PLATFORMS
   ruby
@@ -38,4 +33,4 @@ DEPENDENCIES
   jeweler
   rake
   rspec
-  ruby-debug19
+  ruby-debug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ GEM
       rbx-require-relative (> 0.0.4)
     rake (0.9.2.2)
     rbx-require-relative (0.0.5)
+    rcov (0.9.11)
     rspec (2.8.0)
       rspec-core (~> 2.8.0)
       rspec-expectations (~> 2.8.0)
@@ -32,5 +33,6 @@ PLATFORMS
 DEPENDENCIES
   jeweler
   rake
+  rcov
   rspec
   ruby-debug

--- a/Rakefile
+++ b/Rakefile
@@ -15,18 +15,12 @@ rescue LoadError
   puts "Jeweler (or a dependency) not available. Install it with: sudo gem install jeweler"
 end
 
-require 'spec/rake/spectask'
-Spec::Rake::SpecTask.new(:spec) do |spec|
-  spec.libs << 'lib' << 'spec'
-  spec.spec_files = FileList['spec/**/*_spec.rb']
-end
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec)
 
-Spec::Rake::SpecTask.new(:rcov) do |spec|
-  spec.libs << 'lib' << 'spec'
+RSpec::Core::RakeTask.new(:rcov) do |spec|
   spec.pattern = 'spec/**/*_spec.rb'
   spec.rcov = true
 end
-
-#task :spec => :check_dependencies
 
 task :default => :spec


### PR DESCRIPTION
Hi Ben,

I took the feedback from the previous pull request and modified the Gemfile:

1) Using development group so Jeweler will generate gemspec w/ add_development_dependency
2) Fixed another bug in rspec/rcov rake tasks I found while testing gemspec generation

Thanks for the patience, sorry I managed to hose the autogenerated config with my addition of the Gemfile.

Hopefully this sets it right.
-Winfield
