### PR TITLE
Allow settingslogic to open a remote yml file

### DIFF
--- a/lib/settingslogic.rb
+++ b/lib/settingslogic.rb
@@ -1,5 +1,6 @@
 require "yaml"
 require "erb"
+require 'open-uri'
 
 # A simple settings solution using a YAML file. See README for more information.
 class Settingslogic < Hash
@@ -110,7 +111,7 @@ class Settingslogic < Hash
     when Hash
       self.replace hash_or_file
     else
-      hash = YAML.load(ERB.new(File.read(hash_or_file)).result).to_hash
+      hash = YAML.load(ERB.new(open(hash_or_file).read).result).to_hash
       if self.class.namespace
         hash = hash[self.class.namespace] or return missing_key("Missing setting '#{self.class.namespace}' in #{hash_or_file}")
       end


### PR DESCRIPTION
make File.read OpenURI.open().read.  This allows for people to reference a remote settings file, which is really handy when using on Heroku.

This pull request is early, as to get feedback on what the most robust way to continue would be.  Any feedback would be much appreciated.  I really want it to read from a secured S3 bucket or some other password protected file that I could configure in a single Heroku env config.
