### PR TITLE
Fix Array#flatten on an array containing a Settingslogic object...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "http://rubygems.org"
 group :development do
   gem 'rake'
   gem 'jeweler'
-  gem 'rspec', :require => 'spec'
+  gem 'rspec'
   gem 'rcov'
   if RUBY_VERSION < "1.9"
     gem 'ruby-debug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    archive-tar-minitar (0.5.2)
     columnize (0.3.6)
     diff-lcs (1.1.3)
     git (1.2.5)
@@ -8,24 +9,28 @@ GEM
       bundler (~> 1.0)
       git (>= 1.2.5)
       rake
-    linecache (0.46)
-      rbx-require-relative (> 0.0.4)
+    linecache19 (0.5.12)
+      ruby_core_source (>= 0.1.4)
     rake (0.9.2.2)
-    rbx-require-relative (0.0.5)
     rcov (0.9.11)
-    rspec (2.8.0)
-      rspec-core (~> 2.8.0)
-      rspec-expectations (~> 2.8.0)
-      rspec-mocks (~> 2.8.0)
-    rspec-core (2.8.0)
-    rspec-expectations (2.8.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.8.0)
-    ruby-debug (0.10.4)
-      columnize (>= 0.1)
-      ruby-debug-base (~> 0.10.4.0)
-    ruby-debug-base (0.10.4)
-      linecache (>= 0.3)
+    rspec (2.11.0)
+      rspec-core (~> 2.11.0)
+      rspec-expectations (~> 2.11.0)
+      rspec-mocks (~> 2.11.0)
+    rspec-core (2.11.1)
+    rspec-expectations (2.11.2)
+      diff-lcs (~> 1.1.3)
+    rspec-mocks (2.11.2)
+    ruby-debug-base19 (0.11.25)
+      columnize (>= 0.3.1)
+      linecache19 (>= 0.5.11)
+      ruby_core_source (>= 0.1.4)
+    ruby-debug19 (0.11.6)
+      columnize (>= 0.3.1)
+      linecache19 (>= 0.5.11)
+      ruby-debug-base19 (>= 0.11.19)
+    ruby_core_source (0.1.5)
+      archive-tar-minitar (>= 0.5.2)
 
 PLATFORMS
   ruby
@@ -35,4 +40,4 @@ DEPENDENCIES
   rake
   rcov
   rspec
-  ruby-debug
+  ruby-debug19

--- a/lib/settingslogic.rb
+++ b/lib/settingslogic.rb
@@ -60,12 +60,12 @@ class Settingslogic < Hash
       instance
       true
     end
-    
+
     def reload!
       @instance = nil
       load!
     end
-    
+
     private
       def instance
         return @instance if @instance
@@ -73,7 +73,7 @@ class Settingslogic < Hash
         create_accessors!
         @instance
       end
-      
+
       def method_missing(name, *args, &block)
         instance.send(name, *args, &block)
       end
@@ -124,6 +124,7 @@ class Settingslogic < Hash
   # Called for dynamically-defined keys, and also the first key deferenced at the top-level, if load! is not used.
   # Otherwise, create_accessors! (called by new) will have created actual methods for each key.
   def method_missing(name, *args, &block)
+    super if name === :to_ary # delegate to_ary to Hash
     key = name.to_s
     return missing_key("Missing setting '#{key}' in #{@section}") unless has_key? key
     value = fetch(key)

--- a/spec/settingslogic_spec.rb
+++ b/spec/settingslogic_spec.rb
@@ -4,11 +4,11 @@ describe "Settingslogic" do
   it "should access settings" do
     Settings.setting2.should == 5
   end
-  
+
   it "should access nested settings" do
     Settings.setting1.setting1_child.should == "saweet"
   end
-  
+
   it "should access deep nested settings" do
     Settings.setting1.deep.another.should == "my value"
   end
@@ -35,7 +35,7 @@ describe "Settingslogic" do
     Settings.language.haskell.paradigm.should == 'functional'
     Settings.language.smalltalk.paradigm.should == 'object oriented'
   end
-  
+
   it "should not collide with global methods" do
     Settings3.nested.collides.does.should == 'not either'
     Settings3[:nested] = 'fooey'
@@ -73,7 +73,7 @@ describe "Settingslogic" do
     end
     e.should_not be_nil
     e.message.should =~ /Missing setting 'erlang' in 'language' section/
-    
+
     Settings.language['erlang'].should be_nil
     Settings.language['erlang'] = 5
     Settings.language['erlang'].should == 5
@@ -158,5 +158,14 @@ describe "Settingslogic" do
   it "should be a hash" do
     Settings.send(:instance).should be_is_a(Hash)
   end
-  
+
+  # rspec-core issue 620
+  it "should not blow up if #to_ary is called on it via Array#flatten" do
+    lambda {
+      [ Settings, ['a'] ].flatten
+    }.should_not raise_error
+
+    [Settings, ['a']].flatten.should == [Settings, 'a']
+  end
+
 end


### PR DESCRIPTION
...by delegating method_missing to Hash in the specific case.

On newer rubies, Array#flatten calls #to_ary on everything in the array, which raises a MissingSetting error from a Settingslogic object. This was reported as an rspec-core issue, but is more a ruby/settingslogic deal.

At any rate, you'd see an unhandled `Settingslogic::MissingSetting: Missing setting 'to_ary'` if you happened to have a Settingslogic object in an array that got flattened.

This is particularly a pain point with newer rspec. See https://github.com/rspec/rspec-core/issues/620 for the initial bug report, which was referred to Settingslogic for a fix. I concur.

My editor hates trailing whitespace, so that's redacted in there too :).
