### PR TITLE
Handle empty yaml files.

### DIFF
--- a/lib/settingslogic.rb
+++ b/lib/settingslogic.rb
@@ -111,7 +111,8 @@ class Settingslogic < Hash
     when Hash
       self.replace hash_or_file
     else
-      hash = YAML.load(ERB.new(open(hash_or_file).read).result).to_hash
+      file_contents = open(hash_or_file).read
+      hash = file_contents.empty? ? {} : YAML.load(ERB.new(file_contents).result).to_hash
       if self.class.namespace
         hash = hash[self.class.namespace] or return missing_key("Missing setting '#{self.class.namespace}' in #{hash_or_file}")
       end

--- a/spec/settings_empty.rb
+++ b/spec/settings_empty.rb
@@ -1,0 +1,3 @@
+class SettingsEmpty < Settingslogic
+  source "#{File.dirname(__FILE__)}/settings_empty.yml"
+end

--- a/spec/settingslogic_spec.rb
+++ b/spec/settingslogic_spec.rb
@@ -153,6 +153,10 @@ describe "Settingslogic" do
     Settings.name.should == 'test'
   end
 
+  it "should handle empty file" do
+    SettingsEmpty.keys.should eql([])
+  end
+
   # Put this test last or else call to .instance will load @instance,
   # masking bugs.
   it "should be a hash" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'settings'
 require 'settings2'
 require 'settings3'
 require 'settings4'
+require 'settings_empty'
 
 # Needed to test Settings3
 Object.send :define_method, 'collides' do


### PR DESCRIPTION
Sometimes the yaml file passed to SettingLogic could be empty. This change handles that rather attempt to convert an empty string to a hash and throwing an error.
