### PR TITLE
Fix dynamic settings with falsy values

### DIFF
--- a/lib/settingslogic.rb
+++ b/lib/settingslogic.rb
@@ -158,7 +158,7 @@ class Settingslogic < Hash
   # http://bmorearty.wordpress.com/2009/01/09/fun-with-rubys-instance_eval-and-class_eval/
   def create_accessor_for(key, val=nil)
     return unless key.to_s =~ /^\w+$/  # could have "some-setting:" which blows up eval
-    instance_variable_set("@#{key}", val) if val
+    instance_variable_set("@#{key}", val)
     self.class.class_eval <<-EndEval
       def #{key}
         return @#{key} if @#{key}

--- a/spec/settingslogic_spec.rb
+++ b/spec/settingslogic_spec.rb
@@ -126,6 +126,18 @@ describe "Settingslogic" do
     Settings.language['some-dash-setting#'].should == 'dashtastic'
   end
 
+  it "should handle settings with nil value" do
+    Settings["flag"] = true
+    Settings["flag"] = nil
+    Settings.flag.should == nil
+  end
+
+  it "should handle settings with false value" do
+    Settings["flag"] = true
+    Settings["flag"] = false
+    Settings.flag.should == false
+  end
+
   it "should support instance usage as well" do
     settings = SettingsInst.new(Settings.source)
     settings.setting1.setting1_child.should == "saweet"


### PR DESCRIPTION
Currently it isn't possible to override settings to `false` and `nil` values.

``` ruby
Settings["flag"] = true
Settings["flag"] = nil
Settings["flag"] #=> nil
Settings.flag #=> true <---- this is wrong
```
