### PR TITLE
Properly implement to_hash

### DIFF
--- a/lib/settingslogic.rb
+++ b/lib/settingslogic.rb
@@ -143,6 +143,11 @@ class Settingslogic < Hash
     create_accessor_for(key, val)
   end
 
+  # Returns an instance of a Hash object
+  def to_hash
+    Hash[self]
+  end
+
   # This handles naming collisions with Sinatra/Vlad/Capistrano. Since these use a set()
   # helper that defines methods in Object, ANY method_missing ANYWHERE picks up the Vlad/Sinatra
   # settings!  So settings.deploy_to title actually calls Object.deploy_to (from set :deploy_to, "host"),

--- a/spec/settingslogic_spec.rb
+++ b/spec/settingslogic_spec.rb
@@ -162,5 +162,13 @@ describe "Settingslogic" do
   it "should be a hash" do
     Settings.send(:instance).should be_is_a(Hash)
   end
-  
+
+  describe "#to_hash" do
+    it "should return a new instance of a Hash object" do
+      Settings.to_hash.should be_kind_of(Hash)
+      Settings.to_hash.class.name.should == "Hash"
+      Settings.to_hash.object_id.should_not == Settings.object_id
+    end
+  end
+
 end


### PR DESCRIPTION
Without this, calling to_hash always returned a SettingsLogic instance, which caused problems when calling methods such as #symbolize_keys on the resulting object.
