### PR TITLE
Exceptions are thrown when trying to acces nested property while suppress_errors is enabled.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -72,6 +72,9 @@ If your default settings seem to be overwriting your environment-specific settin
   >> Settings.cool.saweet
   => "nested settings"
 
+  >> Settings.get('cool.saweet')
+  => "nested settings"
+
   >> Settings.neat_setting
   => 800
 

--- a/lib/settingslogic.rb
+++ b/lib/settingslogic.rb
@@ -19,6 +19,10 @@ class Settingslogic < Hash
         curs = curs.send(p)
       end
       curs
+    rescue
+      return nil if suppress_errors
+
+      raise
     end
 
     def source(value = nil)

--- a/spec/settingslogic_spec.rb
+++ b/spec/settingslogic_spec.rb
@@ -1,7 +1,5 @@
 require File.expand_path(File.dirname(__FILE__) + "/spec_helper")
 
-puts "Value: #{Settings.get('setting1.deep.child.value')}"
-
 describe "Settingslogic" do
   it "should access settings" do
     Settings.setting2.should == 5

--- a/spec/settingslogic_spec.rb
+++ b/spec/settingslogic_spec.rb
@@ -1,5 +1,7 @@
 require File.expand_path(File.dirname(__FILE__) + "/spec_helper")
 
+puts "Value: #{Settings.get('setting1.deep.child.value')}"
+
 describe "Settingslogic" do
   it "should access settings" do
     Settings.setting2.should == 5
@@ -114,6 +116,18 @@ describe "Settingslogic" do
   it "should allow suppressing errors" do
     Settings4.non_existent_key.should be_nil
   end
+
+
+  context "#get" do
+    it "should suppress errors for nonexistent nested parameters" do
+      expect { Settings4.get('non.existent.key') }.not_to raise_exception
+    end
+
+    it "should throw an exception for nonexistent nested parameters when suppress_errors=false" do
+      expect { Settings.get('non.existent.key') }.to raise_exception
+    end
+  end
+
 
   # This one edge case currently does not pass, because it requires very
   # esoteric code in order to make it pass.  It was judged not worth fixing,


### PR DESCRIPTION
Example:

```
class Defaults < Settingslogic
  ....
  suppress_errors true
end

Defaults.get('some.nonexistent.property') # Boom!
```
