### PR TITLE
Settingslogic#to_nested_hash converts nested Settingslogic objects to Hash objects

### DIFF
--- a/lib/settingslogic.rb
+++ b/lib/settingslogic.rb
@@ -145,6 +145,10 @@ class Settingslogic < Hash
     end
   end
 
+  def save(path)
+    File.open(path, "w") { |f| f << to_nested_hash.to_yaml }
+  end
+
   # This handles naming collisions with Sinatra/Vlad/Capistrano. Since these use a set()
   # helper that defines methods in Object, ANY method_missing ANYWHERE picks up the Vlad/Sinatra
   # settings!  So settings.deploy_to title actually calls Object.deploy_to (from set :deploy_to, "host"),

--- a/lib/settingslogic.rb
+++ b/lib/settingslogic.rb
@@ -136,6 +136,15 @@ class Settingslogic < Hash
     Hash[self]
   end
 
+  # Convert all nested Settingslogic objects to Hash objects
+  def to_nested_hash
+    inject({}) do |hash, key_value|
+      key, value = key_value
+      hash[key]  = value.respond_to?(:to_nested_hash) ? value.to_nested_hash : value
+      hash
+    end
+  end
+
   # This handles naming collisions with Sinatra/Vlad/Capistrano. Since these use a set()
   # helper that defines methods in Object, ANY method_missing ANYWHERE picks up the Vlad/Sinatra
   # settings!  So settings.deploy_to title actually calls Object.deploy_to (from set :deploy_to, "host"),

--- a/spec/settingslogic_spec.rb
+++ b/spec/settingslogic_spec.rb
@@ -216,6 +216,7 @@ describe "Settingslogic" do
 
   describe "#save(file)" do
     it "should save Settingslogic object such that it can be reloaded later" do
+      Settings.reload!
       Settings["extra"] = {}
       Settings["extra"]["value"] = 123
       Settings.extra.value.should == 123

--- a/spec/settingslogic_spec.rb
+++ b/spec/settingslogic_spec.rb
@@ -204,4 +204,13 @@ describe "Settingslogic" do
     end
   end
 
+  describe "#to_nested_hash" do
+    it "should convert all nested Settingslogic objects to Hash objects" do
+      hash = Settings.to_nested_hash
+      hash.class.should == Hash
+      hash["language"].class.should == Hash
+      hash["language"]["haskell"].class.should == Hash
+      hash["language"]["haskell"]["paradigm"].class.should == String
+    end
+  end
 end

--- a/spec/settingslogic_spec.rb
+++ b/spec/settingslogic_spec.rb
@@ -213,4 +213,17 @@ describe "Settingslogic" do
       hash["language"]["haskell"]["paradigm"].class.should == String
     end
   end
+
+  describe "#save(file)" do
+    it "should save Settingslogic object such that it can be reloaded later" do
+      Settings["extra"] = {}
+      Settings["extra"]["value"] = 123
+      Settings.extra.value.should == 123
+      Settings.save("/tmp/settings.yml")
+
+      later_on = Settingslogic.new("/tmp/settings.yml")
+      later_on.extra.value.should == 123
+    end
+  end
+
 end


### PR DESCRIPTION
Example/spec:

```
hash = Settings.to_nested_hash
hash.class.should == Hash
hash["language"].class.should == Hash
hash["language"]["haskell"].class.should == Hash
hash["language"]["haskell"]["paradigm"].class.should == String
```

Also a `#save(path)` method which uses `to_nested_hash`
