### PR TITLE
Add license information to gemspec

### DIFF
--- a/settingslogic.gemspec
+++ b/settingslogic.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/binarylogic/settingslogic"
   s.summary     = %q{A simple and straightforward settings solution that uses an ERB enabled YAML file and a singleton design pattern.}
   s.description = %q{A simple and straightforward settings solution that uses an ERB enabled YAML file and a singleton design pattern.}
+  s.license     = 'MIT'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
This increases the discoverability of what license this gem uses. See rubygems/rubygems.org#363 or [this blog post](http://www.benjaminfleischer.com/2013/07/12/make-the-world-a-better-place-put-a-license-in-your-gemspec/) for more info.
