### PR TITLE
Nested namespaces

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -61,6 +61,28 @@ If your default settings seem to be overwriting your environment-specific settin
   require 'yaml'
   YAML::ENGINE.yamler= 'syck'
 
+==== Namespaced settings
+
+Maybe you need to use another semantics for your namespace besides the current
+environment. You can put a nested namespace in your settings and you are good
+to go.
+
+  # /some/file/here.yml
+  professional:
+    preferences:
+      order: desc
+  client:
+    prefs:
+      order: asc
+
+  class ProfessionalPreferences < Settingslogic
+    source "/some/file/here.yml"
+    namespace "professional.preferences"
+  end
+
+  >> ProfessionalPreferences.order
+  => "desc"
+
 === 3. Access your settings
 
   >> Rails.env

--- a/lib/settingslogic.rb
+++ b/lib/settingslogic.rb
@@ -12,11 +12,11 @@ class Settingslogic < Hash
     end
         
     # Enables Settings.get('nested.key.name') for dynamic access
-    def get(key)
+    def get(key, hash = nil)
       parts = key.split('.')
-      curs = self
+      curs = hash || self
       while p = parts.shift
-        curs = curs.send(p)
+        curs = curs[p] or (yield p if block_given?)
       end
       curs
     end

--- a/lib/settingslogic.rb
+++ b/lib/settingslogic.rb
@@ -108,20 +108,20 @@ class Settingslogic < Hash
     create_accessors!
   end
 
-  def namespaced_hash(hash, hash_or_file)
-    if self.class.namespace.include? "."
-      nested_namespaced_hash hash, hash_or_file
+  def missing_setting_action(namespace)
+    if namespace.include? "."
+      proc { missing_key "Missing setting '#{setting}' for '#{namespace}' in #{hash_or_file}" }
     else
-      hash[namespace] or return missing_key("Missing setting '#{namespace}' in #{hash_or_file}")
+      proc { missing_key "Missing setting '#{namespace}' in #{hash_or_file}" }
     end
   end
 
-  def nested_namespaced_hash(hash, hash_or_file)
-    self.class.get self.class.namespace, hash do |setting|
-      missing_key "Missing setting '#{setting}' for '#{self.class.namespace}' in #{hash_or_file}"
-    end
+  def namespaced_hash(hash, hash_or_file)
+    namespace = self.class.namespace
+    self.class.get namespace, hash, &missing_setting_action(namespace)
   end
-  private :namespaced_hash, :nested_namespaced_hash
+
+  private :missing_setting_action, :namespaced_hash
 
   # Called for dynamically-defined keys, and also the first key deferenced at the top-level, if load! is not used.
   # Otherwise, create_accessors! (called by new) will have created actual methods for each key.

--- a/spec/settings.rb
+++ b/spec/settings.rb
@@ -4,3 +4,13 @@ end
 
 class SettingsInst < Settingslogic
 end
+
+class SettingsNestedNamespace < Settingslogic
+  source "#{File.dirname(__FILE__)}/settings.yml"
+  namespace "language.smalltalk"
+end
+
+class SettingsInvalidNestedNamespace < Settingslogic
+  source "#{File.dirname(__FILE__)}/settings.yml"
+  namespace "inexistent.namespace.omg"
+end

--- a/spec/settingslogic_spec.rb
+++ b/spec/settingslogic_spec.rb
@@ -190,6 +190,19 @@ describe "Settingslogic" do
     SettingsEmpty.keys.should eql([])
   end
 
+  context "using a nested namespace (`language.smalltalk`)" do
+    it "returns the right internal nested value" do
+      expect(SettingsNestedNamespace.paradigm).to eq "object oriented"
+    end
+
+    context "when namespace doesn't exists" do
+      it "raises the missing key error" do
+        expect { SettingsInvalidNestedNamespace.paradigm }.to \
+          raise_error Settingslogic::MissingSetting
+      end
+    end
+  end
+
   # Put this test last or else call to .instance will load @instance,
   # masking bugs.
   it "should be a hash" do


### PR DESCRIPTION
This PR adds the ability to create a settings class with a nested namespace, so the "base hash" can be fetched from inside some yaml key.

``` ruby
  # /some/file/here.yml
  professional:
    preferences:
      order: desc
  client:
    prefs:
      order: asc

  class ProfessionalPreferences < Settingslogic
    source "/some/file/here.yml"
    namespace "professional.preferences"
  end
```

```
  >> ProfessionalPreferences.order
  => "desc"
```
