### PR TITLE
Update ruby gems source in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     settingslogic (2.0.9)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     diff-lcs (1.1.3)
     rake (10.0.3)


### PR DESCRIPTION
The source :rubygems is deprecated because HTTP requests are insecure. Updated to use https://rubygems.org instead.
