### PR TITLE
Solve issues with aliases after upgrading to Psych ~> 4

### DIFF
--- a/lib/settingslogic.rb
+++ b/lib/settingslogic.rb
@@ -100,7 +100,7 @@ class Settingslogic < Hash
       self.replace hash_or_file
     else
       file_contents = open(hash_or_file).read
-      hash = file_contents.empty? ? {} : YAML.load(ERB.new(file_contents).result).to_hash
+      hash = file_contents.empty? ? {} : parse_yaml_content(file_contents)
       if self.class.namespace
         hash = hash[self.class.namespace] or return missing_key("Missing setting '#{self.class.namespace}' in #{hash_or_file}")
       end
@@ -187,5 +187,13 @@ class Settingslogic < Hash
     return nil if self.class.suppress_errors
 
     raise MissingSetting, msg
+  end
+  
+  private
+  
+  def parse_yaml_content(file_content)
+    YAML.load(ERB.new(file_contents).result, aliases: true).to_hash
+  rescue ArgumentError
+    YAML.load(ERB.new(file_contents).result).to_hash
   end
 end

--- a/lib/settingslogic.rb
+++ b/lib/settingslogic.rb
@@ -192,8 +192,8 @@ class Settingslogic < Hash
   private
   
   def parse_yaml_content(file_content)
-    YAML.load(ERB.new(file_contents).result, aliases: true).to_hash
+    YAML.load(ERB.new(file_content).result, aliases: true).to_hash
   rescue ArgumentError
-    YAML.load(ERB.new(file_contents).result).to_hash
+    YAML.load(ERB.new(file_content).result).to_hash
   end
 end

--- a/spec/settings.yml
+++ b/spec/settings.yml
@@ -13,7 +13,7 @@ language:
   haskell:
     paradigm: functional
   smalltalk:
-    paradigm: object oriented 
+    paradigm: object oriented
 
 collides:
   does: not
@@ -26,3 +26,10 @@ array:
     name: first
   -
     name: second
+
+alias: &default
+  example:
+    key: value
+
+uses_default_alias:
+  <<: *default


### PR DESCRIPTION
Aliases completely break the logic behind `settingslogic` gem after upgrading to the latest Psych version.

It has been described here: https://bugs.ruby-lang.org/issues/17866

I applied the same solution Rails team applies a time ago: https://github.com/rails/rails/commit/179d0a1f474ada02e0030ac3bd062fc653765dbe

It tries to call YAML module with the new arguments and failover over the old parameters interface

Psych diff between 3.3.2 and 4.0.0: https://my.diffend.io/gems/psych/3.3.2/4.0.0